### PR TITLE
Add Windows helper scripts and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Need a quick classroom walkthrough?  `dlp demo` caps the run to a small number o
 dlp demo --steps 100 --batch-size 64
 ```
 
+### Windows shortcuts
+
+On Windows you can double-click the helper batch files in `scripts/windows/` to launch the Typer CLI without opening a terminal manually.  `demo.bat` starts the classroom-friendly demo (`py -m deeplearning_python.cli demo`) and `train.bat` launches the full training workflow (`py -m deeplearning_python.cli train`).
+
+These helpers rely on the Python `py` launcher that ships with the official Windows installers.  If you installed Python from the Microsoft Store or another distribution, ensure the `py` command is available on your `PATH` before using the batch files.
+
 ### Customizing the experiment
 
 Common options (see `dlp train --help` for the full list):

--- a/scripts/windows/demo.bat
+++ b/scripts/windows/demo.bat
@@ -1,0 +1,6 @@
+@echo off
+cd /d "%~dp0"
+cd ..
+cd ..
+py -m deeplearning_python.cli demo %*
+pause

--- a/scripts/windows/train.bat
+++ b/scripts/windows/train.bat
@@ -1,0 +1,6 @@
+@echo off
+cd /d "%~dp0"
+cd ..
+cd ..
+py -m deeplearning_python.cli train %*
+pause


### PR DESCRIPTION
## Summary
- add Windows batch files for launching the demo and training CLI from scripts/windows
- document the new double-click helpers in the README, including their reliance on the Python `py` launcher

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c95a7b3bdc832fa25a0ab5a7aa6502