### PR TITLE
Add notebook training helper and Colab quickstart materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository modernizes the exercises from [*Neural Networks and Deep Learnin
 - **Live Rich dashboard** – animated loss and accuracy charts, gradient norms, step-by-step logs, and ASCII art previews of the current mini-batch so students can “see” what the network is learning.
 - **Checkpointing & metrics export** – periodic checkpoints capture the model, optimizer, and scheduler states; JSONL metrics logs can be replayed or plotted later.
 - **Typer CLI** – launch scripted runs or quick classroom demos with a single command.
+- **Colab-friendly notebook helper** – collect training metrics directly in Python with `run_notebook_training` for plotting inside Google Colab.
 
 ## Getting started
 
@@ -29,6 +30,43 @@ This repository modernizes the exercises from [*Neural Networks and Deep Learnin
 
    Installing the project in editable mode exposes the `dlp` command line tool described below.
 
+## Google Colab quickstart
+
+Running the project in Colab is now a first-class experience. The CLI automatically disables the Rich live dashboard when it detects a non-interactive output stream, and the package exposes a notebook helper that returns metrics directly to Python.
+
+1. Open a new Colab notebook and install the package:
+
+   ```python
+   !pip install --quiet torch torchvision
+   !pip install --quiet git+https://github.com/<REPO_OWNER>/DeepLearningPython.git
+   ```
+
+2. Import the helper and launch a short fake-data run. The helper forces `enable_live=False` and can return a pandas DataFrame when `return_dataframe=True`:
+
+   ```python
+   from pathlib import Path
+   from deeplearning_python import run_notebook_training
+
+   result = run_notebook_training(
+       epochs=1,
+       batch_size=64,
+       fake_data=True,
+       data_dir=Path("/content/data"),
+       log_dir=Path("/content/logs"),
+       checkpoint_dir=Path("/content/checkpoints"),
+       limit_train_batches=2,
+       limit_val_batches=1,
+       return_dataframe=True,
+   )
+
+   metrics_df = result["metrics"]
+   metrics_df.head()
+   ```
+
+3. Plot metrics or continue experimenting as you would locally. Metrics are written to `/content/logs`, and checkpoints land in `/content/checkpoints` by default. Mount Google Drive first if you want these artifacts to persist across sessions.
+
+The repository ships a ready-to-run example notebook at [`notebooks/colab_demo.ipynb`](notebooks/colab_demo.ipynb) that strings these steps together for your classroom or workshop.
+
 ## Live training demo
 
 The new command line interface lives at `src/deeplearning_python/cli.py`.  After installing the package you can launch the interactive trainer:
@@ -43,6 +81,8 @@ The trainer will:
 - display ASCII renderings of the digits in the current mini-batch together with predicted labels
 - write checkpoints to `./artifacts/checkpoints/step_XXXXXXX.pt`
 - append structured metrics to `./artifacts/logs/metrics.jsonl`
+
+When the CLI detects a non-interactive environment (such as a notebook output cell), it automatically suppresses the live Rich dashboard so the logs stay readable. Launch the command from a local terminal to re-enable the animated dashboard.
 
 ### Demo mode
 

--- a/notebooks/colab_demo.ipynb
+++ b/notebooks/colab_demo.ipynb
@@ -1,0 +1,139 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deep Learning Python – Colab demo\n",
+    "Use this notebook inside Google Colab to run the classroom trainer with fake data for a quick sanity check."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Install the package\n",
+    "Replace `<REPO_OWNER>` with the GitHub owner for your fork if you are not using the upstream project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "install"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install --quiet torch torchvision\n",
+    "!pip install --quiet git+https://github.com/<REPO_OWNER>/DeepLearningPython.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. (Optional) Mount Google Drive for persistent checkpoints\n",
+    "Skip this cell if you are happy to keep artifacts in the ephemeral `/content` workspace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "mount"
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from google.colab import drive\n",
+    "\n",
+    "drive.mount('/content/drive')\n",
+    "# checkpoints_dir = Path('/content/drive/MyDrive/dlp_checkpoints')\n",
+    "# checkpoints_dir.mkdir(parents=True, exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Run a short training loop\n",
+    "`run_notebook_training` disables the Rich live dashboard automatically and returns a pandas DataFrame when `return_dataframe=True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "train"
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from deeplearning_python import run_notebook_training\n",
+    "\n",
+    "result = run_notebook_training(\n",
+    "    epochs=1,\n",
+    "    batch_size=64,\n",
+    "    val_batch_size=64,\n",
+    "    learning_rate=0.05,\n",
+    "    optimizer=\"sgd\",\n",
+    "    fake_data=True,\n",
+    "    data_dir=Path(\"/content/data\"),\n",
+    "    log_dir=Path(\"/content/logs\"),\n",
+    "    checkpoint_dir=Path(\"/content/checkpoints\"),\n",
+    "    limit_train_batches=2,\n",
+    "    limit_val_batches=1,\n",
+    "    limit_train_samples=256,\n",
+    "    limit_val_samples=128,\n",
+    "    checkpoint_interval=0,\n",
+    "    preview_interval=0,\n",
+    "    return_dataframe=True,\n",
+    ")\n",
+    "metrics_df = result[\"metrics\"]\n",
+    "metrics_df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Plot metrics\n",
+    "Metrics and checkpoints are written to `/content/logs` and `/content/checkpoints` unless you override the paths above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "plot"
+   },
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "plt.figure(figsize=(8, 4))\n",
+    "plt.plot(metrics_df['step'], metrics_df['loss'], label='loss')\n",
+    "plt.plot(metrics_df['step'], metrics_df['accuracy'], label='accuracy')\n",
+    "plt.xlabel('Step')\n",
+    "plt.legend()\n",
+    "plt.title('Training metrics')\n",
+    "plt.show()\n",
+    "\n",
+    "result['log_path'], result['checkpoint_dir']"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/deeplearning_python/__init__.py
+++ b/src/deeplearning_python/__init__.py
@@ -7,4 +7,16 @@ try:  # pragma: no cover - best effort for editable installs
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "run_notebook_training"]
+
+
+def __getattr__(name: str):  # pragma: no cover - tiny import shim
+    if name == "run_notebook_training":
+        from .notebook import run_notebook_training as helper
+
+        return helper
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - trivial
+    return sorted(__all__)

--- a/src/deeplearning_python/cli.py
+++ b/src/deeplearning_python/cli.py
@@ -120,6 +120,13 @@ def train(
     """Train a network with a live terminal dashboard."""
 
     console = _console(verbose)
+
+    live_mode = live
+    if live_mode and not console.is_terminal:
+        console.log(
+            "Detected a non-interactive output stream; disabling the live dashboard."
+        )
+        live_mode = False
     model_config = ModelConfig(
         name=model,
         hidden_sizes=tuple(hidden_sizes),
@@ -166,7 +173,7 @@ def train(
         scheduler_gamma=scheduler_gamma,
         num_workers=num_workers,
         seed=seed,
-        enable_live=live,
+        enable_live=live_mode,
     )
 
     trainer = Trainer(

--- a/src/deeplearning_python/notebook.py
+++ b/src/deeplearning_python/notebook.py
@@ -1,0 +1,136 @@
+"""Helpers for running the trainer from interactive notebooks."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Iterable, MutableMapping
+
+from rich.console import Console
+
+from .data import DataConfig
+from .models import ModelConfig
+from .training import Trainer, TrainingConfig
+
+__all__ = ["run_notebook_training"]
+
+
+def run_notebook_training(
+    *,
+    model: str = "simple",
+    hidden_sizes: Iterable[int] | None = None,
+    dropout: float = 0.0,
+    epochs: int = 5,
+    batch_size: int = 64,
+    val_batch_size: int | None = None,
+    learning_rate: float = 0.1,
+    optimizer: str = "sgd",
+    momentum: float = 0.9,
+    weight_decay: float = 0.0,
+    scheduler: str = "none",
+    scheduler_step_size: int = 1,
+    scheduler_gamma: float = 0.95,
+    device: str = "auto",
+    data_dir: str | Path = "./data",
+    download: bool = True,
+    fake_data: bool = False,
+    checkpoint_dir: str | Path = "./artifacts/checkpoints",
+    checkpoint_interval: int = 0,
+    log_dir: str | Path = "./artifacts/logs",
+    metrics_filename: str = "metrics.jsonl",
+    resume_from: str | Path | None = None,
+    log_interval: int = 10,
+    preview_interval: int = 25,
+    evaluate_every: int = 1,
+    limit_train_batches: int | None = None,
+    limit_val_batches: int | None = None,
+    limit_train_samples: int | None = None,
+    limit_val_samples: int | None = None,
+    mixed_precision: bool = False,
+    gradient_clip: float | None = None,
+    num_workers: int = 0,
+    seed: int = 0,
+    verbose: bool = True,
+    return_dataframe: bool = False,
+) -> MutableMapping[str, Any]:
+    """Train the classroom model from a notebook and return the collected metrics.
+
+    Parameters mirror the Typer CLI defaults while forcing ``enable_live`` off so
+    notebook output remains readable. Set ``return_dataframe`` when you prefer a
+    pandas ``DataFrame`` instead of a list of ``StepMetrics`` objects.
+    """
+
+    resolved_hidden_sizes = tuple(hidden_sizes) if hidden_sizes is not None else (128, 64)
+
+    model_config = ModelConfig(
+        name=model,
+        hidden_sizes=resolved_hidden_sizes,
+        dropout=dropout,
+    )
+    data_config = DataConfig(
+        data_dir=Path(data_dir),
+        batch_size=batch_size,
+        val_batch_size=val_batch_size,
+        download=download,
+        num_workers=num_workers,
+        limit_train_samples=limit_train_samples,
+        limit_val_samples=limit_val_samples,
+        seed=seed,
+        use_fake_data=fake_data,
+    )
+    training_config = TrainingConfig(
+        epochs=epochs,
+        optimizer=optimizer,
+        learning_rate=learning_rate,
+        momentum=momentum,
+        weight_decay=weight_decay,
+        batch_size=batch_size,
+        val_batch_size=val_batch_size,
+        device=device,
+        checkpoint_dir=Path(checkpoint_dir),
+        checkpoint_interval=checkpoint_interval,
+        log_dir=Path(log_dir),
+        metrics_filename=metrics_filename,
+        resume_from=Path(resume_from) if resume_from else None,
+        preview_interval=preview_interval,
+        log_interval=log_interval,
+        evaluate_every=evaluate_every,
+        limit_train_batches=limit_train_batches,
+        limit_val_batches=limit_val_batches,
+        limit_train_samples=limit_train_samples,
+        limit_val_samples=limit_val_samples,
+        mixed_precision=mixed_precision,
+        gradient_clip=gradient_clip,
+        scheduler=scheduler,
+        scheduler_step_size=scheduler_step_size,
+        scheduler_gamma=scheduler_gamma,
+        num_workers=num_workers,
+        seed=seed,
+        enable_live=False,
+    )
+
+    console = Console(log_path=False, quiet=not verbose)
+    trainer = Trainer(
+        model_config=model_config,
+        data_config=data_config,
+        training_config=training_config,
+        console=console,
+    )
+    trainer.train()
+
+    history = list(trainer.metrics_tracker.history)
+    metrics: Any = history
+    if return_dataframe:
+        try:
+            import pandas as pd  # type: ignore
+        except ImportError as error:  # pragma: no cover - exercised when pandas missing
+            raise RuntimeError(
+                "pandas is required when return_dataframe=True; install pandas first."
+            ) from error
+        metrics = pd.DataFrame([asdict(entry) for entry in history])
+
+    return {
+        "metrics": metrics,
+        "log_path": trainer.log_path,
+        "checkpoint_dir": Path(training_config.checkpoint_dir),
+    }

--- a/src/deeplearning_python/visualization.py
+++ b/src/deeplearning_python/visualization.py
@@ -11,7 +11,11 @@ import torch
 from rich.console import Console, RenderableType
 from rich.layout import Layout
 from rich.panel import Panel
-from rich.plot import Plot
+# Rich switched the optional plotting helpers to a separate extra in newer releases.
+try:  # pragma: no cover - import may fail when the extra is missing
+    from rich.plot import Plot
+except ImportError:  # pragma: no cover
+    Plot = None  # type: ignore[assignment]
 from rich.progress import Progress
 from rich.rule import Rule
 from rich.table import Table
@@ -102,6 +106,11 @@ class TrainingDashboard:
         return Panel(table, title="Current Metrics", padding=(1, 2))
 
     def _render_loss_plot(self) -> RenderableType:
+        if Plot is None:
+            return Panel(
+                "Install `rich[plot]` to enable inline charts.", title="Loss History"
+            )
+
         plot = Plot(width=80, height=12, title="Loss History")
         if not self.history:
             plot.add_series("loss", [0.0, 0.0])
@@ -112,6 +121,12 @@ class TrainingDashboard:
         return plot
 
     def _render_accuracy_plot(self) -> RenderableType:
+        if Plot is None:
+            return Panel(
+                "Install `rich[plot]` to enable inline charts.",
+                title="Accuracy History",
+            )
+
         plot = Plot(width=80, height=12, title="Accuracy History")
         if not self.history:
             plot.add_series("accuracy", [0.0, 0.0])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 from typer.testing import CliRunner
@@ -61,3 +62,77 @@ def test_cli_train_fake_data(tmp_path: Path) -> None:
     assert contents, "expected metrics log to contain at least one entry"
     assert any('"phase": "train"' in line for line in contents)
     assert not list(checkpoint_dir.glob("*.pt")), "checkpoints should be disabled"
+
+
+def test_cli_disables_live_for_non_tty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from deeplearning_python import cli as cli_module
+
+    messages: list[str] = []
+
+    class DummyConsole:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            self.is_terminal = False
+
+        def log(self, message: str) -> None:
+            messages.append(message)
+
+        def print(self, *_: Any, **__: Any) -> None:
+            pass
+
+    monkeypatch.setattr(cli_module, "_console", lambda verbose: DummyConsole())
+
+    captured: dict[str, Any] = {}
+
+    class DummyTrainer:
+        def __init__(self, *, training_config, console, **kwargs: Any) -> None:
+            captured["enable_live"] = training_config.enable_live
+            captured["console"] = console
+
+        def train(self) -> None:
+            pass
+
+    monkeypatch.setattr(cli_module, "Trainer", DummyTrainer)
+
+    checkpoint_dir = tmp_path / "ckpts"
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "--epochs",
+            "1",
+            "--batch-size",
+            "8",
+            "--learning-rate",
+            "0.01",
+            "--optimizer",
+            "sgd",
+            "--device",
+            "cpu",
+            "--fake-data",
+            "--log-dir",
+            str(tmp_path),
+            "--checkpoint-dir",
+            str(checkpoint_dir),
+            "--metrics-filename",
+            "metrics.jsonl",
+            "--limit-train-batches",
+            "1",
+            "--limit-val-batches",
+            "1",
+            "--limit-train-samples",
+            "16",
+            "--limit-val-samples",
+            "16",
+            "--checkpoint-interval",
+            "0",
+            "--log-interval",
+            "1",
+            "--preview-interval",
+            "1",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["enable_live"] is False
+    assert messages, "expected a notice about disabling the live dashboard"

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+
+from deeplearning_python.notebook import run_notebook_training
+
+
+def test_notebook_helper_returns_history(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from deeplearning_python import training as training_module
+
+    live_called = {"value": False}
+
+    class SentinelLive:
+        def __init__(self, *args, **kwargs) -> None:  # pragma: no cover - not executed
+            live_called["value"] = True
+
+        def start(self) -> None:  # pragma: no cover - not executed
+            pass
+
+        def update(self, *args, **kwargs) -> None:  # pragma: no cover - not executed
+            pass
+
+        def stop(self) -> None:  # pragma: no cover - not executed
+            pass
+
+    monkeypatch.setattr(training_module, "Live", SentinelLive)
+
+    result = run_notebook_training(
+        epochs=1,
+        batch_size=8,
+        val_batch_size=8,
+        learning_rate=0.01,
+        optimizer="sgd",
+        device="cpu",
+        fake_data=True,
+        data_dir=tmp_path / "data",
+        log_dir=tmp_path / "logs",
+        checkpoint_dir=tmp_path / "ckpts",
+        metrics_filename="metrics.jsonl",
+        limit_train_batches=1,
+        limit_val_batches=1,
+        limit_train_samples=16,
+        limit_val_samples=16,
+        preview_interval=0,
+        log_interval=1,
+        checkpoint_interval=0,
+        verbose=False,
+    )
+
+    assert not live_called["value"], "live dashboard should stay disabled in notebooks"
+
+    metrics = result["metrics"]
+    assert len(metrics) > 0, "expected at least one training step"
+
+    log_path = Path(result["log_path"])
+    assert log_path.exists()
+    assert log_path.read_text().strip(), "metrics log should contain entries"


### PR DESCRIPTION
## Summary
- auto-disable the CLI live dashboard when stdout is not interactive and cover it with tests
- add a `run_notebook_training` helper plus a Colab demo notebook and documentation updates for notebook workflows
- make the Rich dashboard resilient to missing `rich.plot`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca5648bf78832fb55d53e0f9502f27